### PR TITLE
Add tools to path

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,7 @@ Afterward, export the environment variables:
 ```sh
 export DEVKITPRO=/opt/devkitpro
 export DEVKITARM=/opt/devkitpro/devkitARM
+export PATH=$PATH:$DEVKITPRO/tools/bin
 ```
 ### Installing tools
 #### agbcc


### PR DESCRIPTION
Adds the tools from devkitpro to the system path, as I forgot to include the command in the initial instructions.
This should fix issues with `bin2s` and `gbafix` not being found.